### PR TITLE
Enforced Leading Zeros on Length-3 Floats / Added Badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 
 # Relogio - Terminal Clock in Rust
+
+[![Build Status](https://travis-ci.org/bmitch/relogio.svg?branch=master)](https://travis-ci.org/bmitch/relogio)
+
 ## What is this?
 This is a project I am using as a means to help me learn Rust. I am new to Rust so the code may not be "ideal". I am very open to any and all feedback and would appreciate any.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,6 @@ fn main() {
 
     // https://en.wikipedia.org/wiki/Geometric_Shapes
     // https://en.wikipedia.org/wiki/Box_Drawing_(Unicode_block)
-    
     loop {
         let date = Local::now();
         let now = Utc::now();
@@ -108,8 +107,7 @@ fn main() {
                 time_progress_window.printw("░");
             }
         }
-        let r1_format = format!("{:0>10}", minute_progress_percentage_complete);
-        let formatted_number = format!("{:.*}", 2, r1_format);
+        let formatted_number = format!("{:.*}", 2, minute_progress_percentage_complete);
         time_progress_window.printw(" ");
         time_progress_window.printw(formatted_number.to_string());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ fn main() {
 
     // https://en.wikipedia.org/wiki/Geometric_Shapes
     // https://en.wikipedia.org/wiki/Box_Drawing_(Unicode_block)
+    
     loop {
         let date = Local::now();
         window.color_set(1);
@@ -101,7 +102,8 @@ fn main() {
                 time_progress_window.printw("░");
             }
         }
-        let formatted_number = format!("{:.*}", 2, minute_progress_percentage_complete);
+        let r1_format = format!("{:0>10}", minute_progress_percentage_complete);
+        let formatted_number = format!("{:.*}", 2, r1_format);
         time_progress_window.printw(" ");
         time_progress_window.printw(formatted_number.to_string());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ fn main() {
                 time_progress_window.printw("░");
             }
         }
-        let formatted_number = format!("{:.*}", 2, minute_progress_percentage_complete);
+        let formatted_number = format!("{:0>5.*}", 5, format!("{:.*}", 2, minute_progress_percentage_complete));
         time_progress_window.printw(" ");
         time_progress_window.printw(formatted_number.to_string());
 
@@ -125,7 +125,7 @@ fn main() {
                 time_progress_window.printw("░");
             }
         }
-        let formatted_number = format!("{:.*}", 2, hour_progress_percentage_complete);
+        let formatted_number = format!("{:0>5.*}", 5, format!("{:.*}", 2, hour_progress_percentage_complete));
         time_progress_window.printw(" ");
         time_progress_window.printw(formatted_number.to_string());
 
@@ -144,7 +144,7 @@ fn main() {
                 time_progress_window.printw("░");
             }
         }
-        let formatted_number = format!("{:.*}", 2, day_progress_percentage_complete);
+        let formatted_number = format!("{:0>5.*}", 5, format!("{:.*}", 2, day_progress_percentage_complete));
         time_progress_window.printw(" ");
         time_progress_window.printw(formatted_number.to_string());
 
@@ -164,7 +164,7 @@ fn main() {
                 time_progress_window.printw("░");
             }
         }
-        let formatted_number = format!("{:.*}", 2, month_progress_percentage_complete);
+        let formatted_number = format!("{:0>5.*}", 5, format!("{:.*}", 2, month_progress_percentage_complete));
         time_progress_window.printw(" ");
         time_progress_window.printw(formatted_number.to_string());
 
@@ -185,7 +185,7 @@ fn main() {
                 time_progress_window.printw("░");
             }
         }
-        let formatted_number = format!("{:.*}", 2, year_progress_percentage_complete);
+        let formatted_number = format!("{:0>5.*}", 5, format!("{:.*}", 2, year_progress_percentage_complete));
         time_progress_window.printw(" ");
         time_progress_window.printw(formatted_number.to_string());
 


### PR DESCRIPTION
Related issues: [bmitch/relogio Issue #12](https://github.com/bmitch/relogio/issues/12), [bmitch/relogio Issue #10](https://github.com/bmitch/relogio/issues/10)

Fixed float formatting so that numbers with a length of 3 (such as `9.22`) were padded with a leading zero (making it `09.22`).

Added a `travis-ci` build badge to the README to reflect build status.